### PR TITLE
Fixing issue with multi-line fields (only first line was captured)

### DIFF
--- a/consult-mu.el
+++ b/consult-mu.el
@@ -519,7 +519,7 @@ This function converts each character in FLAG to an expanded string of the flag 
   (when (or (derived-mode-p 'message-mode)
             (derived-mode-p 'mu4e-view-mode)
             (derived-mode-p 'org-msg-edit-mode)
-            (derived-mode-p'mu4e-compose-mode))
+            (derived-mode-p 'mu4e-compose-mode))
     (let ((field (or field
                      (s-lower-camel-case (consult--read '("Subject" "From" "To" "Cc" "Bcc" "Reply-To" "Date" "Attachments" "Tags" "Flags" "Maildir" "Summary")
                                                         :prompt "Header Field: ")))))
@@ -536,8 +536,9 @@ This function converts each character in FLAG to an expanded string of the flag 
             (let* ((next-start (point))
                    (next-end (line-end-position))
                    (next-line (buffer-substring-no-properties next-start next-end)))
-              (setq match (eq nil (string-match ":" next-line))))))
-        (if end
+              (setq match (and (eq nil (string-match ":" next-line))
+                               (not (string-prefix-p "--" next-line)))))))
+        (if (and end (> end (+ start 2)))
             (progn
               (setq str (string-replace "\n" " " (string-trim (buffer-substring-no-properties start end))))
               (if (not (string-empty-p str)) str nil))

--- a/consult-mu.el
+++ b/consult-mu.el
@@ -525,7 +525,7 @@ This function converts each character in FLAG to an expanded string of the flag 
                                                         :prompt "Header Field: ")))))
       (if (equal field "attachments") (setq field "\\(attachment\\|attachments\\)"))
       (goto-char (point-min))
-      (let* ((match (re-search-forward field nil t))
+      (let* ((match (re-search-forward (concat"^" field) nil t))
              (start (point))
              (end nil)
              (str nil))


### PR DESCRIPTION
When invoking `consult-mu-contacts` while being in a mu4e message buffer, I received an error message due to the "To:" field spanning more than one line, like:

> To: "A B" <a.b@c.d>, "E F"
>    <e.f@g.h>

Basically, `consult-mu--message-get-header-field` only considered the line containing "To:" instead of the potential subsequent lines. This pull request is addressing this by scanning for all lines following a given field that do not contain a ":", joining those lines into one string without newlines.