### PR TITLE
remove mu4e from package requirements

### DIFF
--- a/consult-mu.el
+++ b/consult-mu.el
@@ -6,11 +6,12 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 1.0
-;; Package-Requires: ((emacs "28.0") (consult "0.34") (mu4e "1.10.8"))
+;; Package-Requires: ((emacs "28.0") (consult "0.34"))
 ;; Homepage: https://github.com/armindarvish/consult-mu
 ;; Keywords: convenience, matching, tools, email
 
 ;;; Commentary:
+;;  This package requires mu4e version "1.10.8" or later
 
 ;;; Code:
 

--- a/consult-mu.org
+++ b/consult-mu.org
@@ -12,11 +12,12 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 1.0
-;; Package-Requires: ((emacs "28.0") (consult "0.34") (mu4e "1.10.8"))
+;; Package-Requires: ((emacs "28.0") (consult "0.34"))
 ;; Homepage: https://github.com/armindarvish/consult-mu
 ;; Keywords: convenience, matching, tools, email
 
 ;;; Commentary:
+;;  This package requires mu4e version "1.10.8" or later
 
 ;;; Code:
 


### PR DESCRIPTION
Since mu4e is not a stand-alone emacs package and is often installed
by installing and compiling mu, we should not decalre mu4e
as a dependency under "Package-Requires".

Addresses #34