### PR TITLE
Fixing issue with multi-line fields (only first line was captured)

### DIFF
--- a/consult-mu.el
+++ b/consult-mu.el
@@ -543,15 +543,30 @@ This function converts each character in FLAG to an expanded string of the flag 
   (when (or (derived-mode-p 'message-mode)
             (derived-mode-p 'mu4e-view-mode)
             (derived-mode-p 'org-msg-edit-mode)
-            (derived-mode-p'mu4e-compose-mode))
+            (derived-mode-p 'mu4e-compose-mode))
     (let ((field (or field
                      (s-lower-camel-case (consult--read '("Subject" "From" "To" "Cc" "Bcc" "Reply-To" "Date" "Attachments" "Tags" "Flags" "Maildir" "Summary")
                       :prompt "Header Field: ")))))
       (if (equal field "attachments") (setq field "\\(attachment\\|attachments\\)"))
       (goto-char (point-min))
-      (let* ((match (re-search-forward (concat "^" field ": ") nil t))
-            (str (if match (string-trim (buffer-substring-no-properties (point) (point-at-eol))))))
-        (if (string-empty-p str) nil str))))))
+      (let* ((match (re-search-forward (concat"^" field) nil t))
+             (start (point))
+             (end nil)
+             (str nil))
+        (save-excursion
+          (while match
+            (setq end (line-end-position))
+            (goto-char (+ 1 end))
+            (let* ((next-start (point))
+                   (next-end (line-end-position))
+                   (next-line (buffer-substring-no-properties next-start next-end)))
+              (setq match (and (eq nil (string-match ":" next-line))
+                               (not (string-prefix-p "--" next-line)))))))
+        (if (and end (> end (+ start 2)))
+            (progn
+              (setq str (string-replace "\n" " " (string-trim (buffer-substring-no-properties start end))))
+              (if (not (string-empty-p str)) str nil))
+          nil))))))
 
 (defun consult-mu--headers-append-handler (msglst)
   "Overrides `mu4e~headers-append-handler' for `consult-mu'.

--- a/consult-mu.org
+++ b/consult-mu.org
@@ -601,15 +601,30 @@ This function converts each character in FLAG to an expanded string of the flag 
   (when (or (derived-mode-p 'message-mode)
             (derived-mode-p 'mu4e-view-mode)
             (derived-mode-p 'org-msg-edit-mode)
-            (derived-mode-p'mu4e-compose-mode))
+            (derived-mode-p 'mu4e-compose-mode))
     (let ((field (or field
                      (s-lower-camel-case (consult--read '("Subject" "From" "To" "Cc" "Bcc" "Reply-To" "Date" "Attachments" "Tags" "Flags" "Maildir" "Summary")
                       :prompt "Header Field: ")))))
       (if (equal field "attachments") (setq field "\\(attachment\\|attachments\\)"))
       (goto-char (point-min))
-      (let* ((match (re-search-forward (concat "^" field ": ") nil t))
-            (str (if match (string-trim (buffer-substring-no-properties (point) (point-at-eol))))))
-        (if (string-empty-p str) nil str))))))
+      (let* ((match (re-search-forward (concat"^" field) nil t))
+             (start (point))
+             (end nil)
+             (str nil))
+        (save-excursion
+          (while match
+            (setq end (line-end-position))
+            (goto-char (+ 1 end))
+            (let* ((next-start (point))
+                   (next-end (line-end-position))
+                   (next-line (buffer-substring-no-properties next-start next-end)))
+              (setq match (and (eq nil (string-match ":" next-line))
+                               (not (string-prefix-p "--" next-line)))))))
+        (if (and end (> end (+ start 2)))
+            (progn
+              (setq str (string-replace "\n" " " (string-trim (buffer-substring-no-properties start end))))
+              (if (not (string-empty-p str)) str nil))
+          nil))))))
 #+end_src
 
 *** mu4e and message backend
@@ -2547,7 +2562,7 @@ INITIAL is the initial input in the minibuffer."
 #+begin_src emacs-lisp
 ;;;  consult-mu-compose.el ends here
 #+end_src
-* consult-mu-compose-embark.rl
+* consult-mu-compose-embark.el
 :PROPERTIES:
 :header-args:emacs-lisp: :results none :mkdirp yes :link yes :tangle ./extras/consult-mu-compose-embark.el
 :END:


### PR DESCRIPTION
When invoking `consult-mu-contacts` while being in a mu4e message buffer, the "To:" field could span more than one line, yielding an error, e.g.:

> To: "A B" a.b@c.d, "E F"
> e.f@g.h

Basically, `consult-mu--message-get-header-field` only considered the line containing "To:" instead of the potential subsequent lines. This commit addresses this by scanning for all lines following a given field that do not contain a ":", joining those lines into one string without newlines.

PS: This is an improved version of an earlier PR, which accidentally edited the .el files instead of the .org file.