### PR TITLE
Fixing `consult-mu--message-get-header-field' regex for empty fields

### DIFF
--- a/consult-mu.el
+++ b/consult-mu.el
@@ -532,7 +532,7 @@ This function converts each character in FLAG to an expanded string of the flag 
                                                             :prompt "Header Field: ")))))
           (if (equal field "attachments") (setq field "\\(attachment\\|attachments\\)"))
           (goto-char (point-min))
-          (let* ((match (re-search-forward (concat "^" field ": \\(?1:[[:ascii:][:nonascii:]]+?\\)\n.*?: ") nil t))
+          (let* ((match (re-search-forward (concat "^" field ": \\(?1:[[:ascii:][:nonascii:]]*?\\)\n.*?\\(: \\|--\\)") nil t))
                  (str (if match (string-trim (match-string 1)))))
             (if (string-empty-p str) nil str)))))))
 

--- a/consult-mu.org
+++ b/consult-mu.org
@@ -590,7 +590,7 @@ This function converts each character in FLAG to an expanded string of the flag 
                                                             :prompt "Header Field: ")))))
           (if (equal field "attachments") (setq field "\\(attachment\\|attachments\\)"))
           (goto-char (point-min))
-          (let* ((match (re-search-forward (concat "^" field ": \\(?1:[[:ascii:][:nonascii:]]+?\\)\n.*?: ") nil t))
+          (let* ((match (re-search-forward (concat "^" field ": \\(?1:[[:ascii:][:nonascii:]]*?\\)\n.*?\\(: \\|--\\)") nil t))
                  (str (if match (string-trim (match-string 1)))))
             (if (string-empty-p str) nil str)))))))
 #+end_src


### PR DESCRIPTION
When a field is empty, notably "Cc: " or "Bcc: ", the remainder of the email was matched instead of just the empty field contents.

This fixes #44, while newlines in fields are still handled correctly.