### PR TITLE
Fix byte compile errors

### DIFF
--- a/consult-mu-embark.el
+++ b/consult-mu-embark.el
@@ -107,7 +107,7 @@
 
     (with-current-buffer consult-mu-view-buffer-name
       (kill-new (consult-mu--message-get-header-field))
-      (consult-mu--pulse-region (point) (point-at-eol)))))
+      (consult-mu--pulse-region (point) (pos-eol)))))
 
 (defun consult-mu-embark-save-attachmnts (cand)
   "Save attachments of CAND."
@@ -130,7 +130,7 @@
     (with-current-buffer consult-mu-view-buffer-name
       (goto-char (point-min))
       (re-search-forward "^\\(Attachment\\|Attachments\\): " nil t)
-      (consult-mu--pulse-region (point) (point-at-eol))
+      (consult-mu--pulse-region (point) (pos-eol))
       (mu4e-view-save-attachments t))))
 
 (defun consult-mu-embark-search-messages-from-contact (cand)

--- a/consult-mu-embark.el
+++ b/consult-mu-embark.el
@@ -94,7 +94,6 @@
   (let* ((msg (get-text-property 0 :msg cand))
          (query (get-text-property 0 :query cand))
          (type (get-text-property 0 :type cand))
-         (newcand (cons cand `(:msg ,msg :query ,query :type ,type)))
          (msg-id (plist-get msg :message-id)))
     (if (equal type :async)
         (consult-mu--update-headers query t msg :async))
@@ -114,7 +113,6 @@
   (let* ((msg (get-text-property 0 :msg cand))
          (query (get-text-property 0 :query cand))
          (type (get-text-property 0 :type cand))
-         (newcand (cons cand `(:msg ,msg :query ,query :type ,type)))
          (msg-id (plist-get msg :message-id)))
 
     (if (equal type :async)


### PR DESCRIPTION
Without these changes, the byte compiler is unable to process consult-mu-embark.el file.