### PR TITLE
Add maildir header support and customizable preview function to consult-mu

### DIFF
--- a/consult-mu.el
+++ b/consult-mu.el
@@ -263,6 +263,13 @@ This defines whether `consult-mu--reply-action' should reply to all or not."
                  (const :tag "Do not reply to all" nil)
                  (const :tag "Always reply to all" t)))
 
+(defcustom consult-mu-preview-function #'consult-mu--preview
+"The function that is used when previewing a message.
+By default it is bound to `consult-mu--preview'."
+  :group 'consult-mu
+  :type '(choice (function :tag "(Default) View Message a the preview buffer" consult-mu--preview)
+                 (function :tag "Custom Function")))
+
 (defcustom consult-mu-action #'consult-mu--view-action
   "The function that is used when selecting a message.
 By default it is bound to `consult-mu--view-action'."
@@ -386,6 +393,12 @@ By default inherits from `font-lock-function-call-face'.")
   "URL face in `consult-mu' minibuffer annotations;
 
 By default inherits from `link'.")
+
+(defface consult-mu-maildir-face
+  `((t :inherit 'font-lock-function-name-face))
+  "Maildir face in `consult-mu' minibuffer annotations;
+
+By default inherits from `font-lock-function-name-face'.")
 
 (defun consult-mu--pulse-regexp (regexp)
   "Find and pulse REGEXP."
@@ -993,7 +1006,7 @@ STRING."
                             ("m" (let ((maildir (plist-get msg :maildir))
                                        (length (string-to-number (substring c 1 nil))))
                                    (if maildir
-                                       (propertize (if (> length 0) (consult-mu--set-string-width maildir length) maildir) 'face 'consult-mu-count-face))))
+                                       (propertize (if (> length 0) (consult-mu--set-string-width maildir length) maildir) 'face 'consult-mu-maildir-face))))
                             (_ nil))
                           "  ")))
 
@@ -1125,6 +1138,25 @@ To use this as the default action for `consult-mu', set
     (consult-mu--view msg nil consult-mu-mark-viewed-as-read match-str)
     (consult-mu-overlays-toggle consult-mu-view-buffer-name)))
 
+(defun consult-mu--preview (cand)
+  "Preview the candidate, CAND.
+
+This is used to create a preview of message in
+`consult-mu-view-buffer-name' when `consult-mu-preview-key' is pressed
+in the minibuffer."
+      (when-let* ((info (cdr cand))
+                  (msg (plist-get info :msg))
+                  (msgid (substring-no-properties (plist-get msg :message-id)))
+                  (query (plist-get info :query))
+                  (match-str (car (consult--command-split query)))
+                  (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
+                  (buffer consult-mu-view-buffer-name))
+        (add-to-list 'consult-mu--view-buffers-list buffer)
+        (funcall (consult--buffer-preview) 'preview
+                 (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
+        (with-current-buffer consult-mu-view-buffer-name
+          (unless (one-window-p) (delete-other-windows)))))
+
 (defun consult-mu--reply (msg &optional wide-reply)
   "Reply to MSG using `mu4e-compose-reply'.
 
@@ -1251,29 +1283,15 @@ messages."
 This is passed as STATE to `consult--read' and is used to preview or do
 other actions on the candidate."
   (lambda (action cand)
-    (let ((preview (consult--buffer-preview)))
-      (pcase action
-        ('preview
-         (if cand
-             (when-let* ((info (cdr cand))
-                         (msg (plist-get info :msg))
-                         (query (plist-get info :query))
-                         (msgid (substring-no-properties (plist-get msg :message-id)))
-                         (match-str (car (consult--command-split query)))
-                         (match-str (car (consult--command-split query)))
-                         (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
-                         (buffer consult-mu-view-buffer-name))
-               ;;(get-buffer-create consult-mu-view-buffer-name)
-               (add-to-list 'consult-mu--view-buffers-list buffer)
-               (funcall preview action
-                        (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
-               (with-current-buffer consult-mu-view-buffer-name
-                 (unless (one-window-p) (delete-other-windows))))))
-        ('return
-         (save-mark-and-excursion
-           (consult-mu--execute-all-marks))
-         (setq consult-mu--override-group nil)
-         cand)))))
+    (pcase action
+      ('preview
+       (if cand
+           (funcall consult-mu-preview-function cand)))
+      ('return
+       (save-mark-and-excursion
+         (consult-mu--execute-all-marks))
+       (setq consult-mu--override-group nil)
+         cand))))
 
 (defun consult-mu--dynamic (prompt collection &optional initial)
   "Query mu4e messages dyunamically.
@@ -1448,26 +1466,14 @@ If HIGHLIGHT is t, input is highlighted with
 This is passed as STATE to `consult--read' and is used to preview or do
 other actions on the candidate."
   (lambda (action cand)
-    (let ((preview (consult--buffer-preview)))
       (pcase action
         ('preview
          (if cand
-             (when-let* ((info (cdr cand))
-                         (msg (plist-get info :msg))
-                         (msgid (substring-no-properties (plist-get msg :message-id)))
-                         (query (plist-get info :query))
-                         (match-str (car (consult--command-split query)))
-                         (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
-                         (buffer consult-mu-view-buffer-name))
-               (add-to-list 'consult-mu--view-buffers-list buffer)
-               (funcall preview action
-                        (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
-               (with-current-buffer consult-mu-view-buffer-name
-                 (unless (one-window-p) (delete-other-windows))))))
+             (funcall consult-mu-preview-function cand)))
         ('return
          (save-mark-and-excursion
            (consult-mu--execute-all-marks))
-         cand)))))
+         cand))))
 
 (defun consult-mu--async-transform (input)
   "Add annotation to minibuffer candiates for `consult-mu'.

--- a/consult-mu.el
+++ b/consult-mu.el
@@ -136,6 +136,7 @@ The list of available fields are:
   %c  cc \(i.e. cc: field of the email\)
   %h  bcc \(i.e. bcc: field of the email\)
   %r  date chaged \(as defined by :changed in mu4e\)
+  %m  maildir \(i.e. mail dir path of email such as “~/maildir/inbox”\)
 
 For exmaple, “%d15%s50” means 15 characters for date and 50 charcters for
 subject, and “%d13%s37%f17” would make a header containing 13 characters
@@ -989,6 +990,10 @@ STRING."
                                        (length (string-to-number (substring c 1 nil))))
                                    (if changed
                                        (propertize (if (> length 0) (consult-mu--set-string-width changed length) changed) 'face 'consult-mu-tags-face))))
+                            ("m" (let ((maildir (plist-get msg :maildir))
+                                       (length (string-to-number (substring c 1 nil))))
+                                   (if maildir
+                                       (propertize (if (> length 0) (consult-mu--set-string-width maildir length) maildir) 'face 'consult-mu-count-face))))
                             (_ nil))
                           "  ")))
 

--- a/consult-mu.org
+++ b/consult-mu.org
@@ -155,6 +155,7 @@ The list of available fields are:
   %c  cc \(i.e. cc: field of the email\)
   %h  bcc \(i.e. bcc: field of the email\)
   %r  date chaged \(as defined by :changed in mu4e\)
+  %m  maildir \(i.e. mail dir path of email such as “~/maildir/inbox”\)
 
 For exmaple, “%d15%s50” means 15 characters for date and 50 charcters for
 subject, and “%d13%s37%f17” would make a header containing 13 characters
@@ -412,6 +413,14 @@ By default inherits from `font-lock-function-call-face'.")
   "URL face in `consult-mu' minibuffer annotations;
 
 By default inherits from `link'.")
+
+(defface consult-mu-maildir-face
+  `((t :inherit 'font-lock-function-name-face))
+  "Maildir face in `consult-mu' minibuffer annotations;
+
+By default inherits from `font-lock-function-name-face'.")
+
+
 
 #+end_src
 
@@ -1101,6 +1110,10 @@ STRING."
                                        (length (string-to-number (substring c 1 nil))))
                                    (if changed
                                        (propertize (if (> length 0) (consult-mu--set-string-width changed length) changed) 'face 'consult-mu-tags-face))))
+                            ("m" (let ((maildir (plist-get msg :maildir))
+                                       (length (string-to-number (substring c 1 nil))))
+                                   (if maildir
+                                       (propertize (if (> length 0) (consult-mu--set-string-width maildir length) maildir) 'face 'consult-mu-maildir-face))))
                             (_ nil))
                           "  ")))
 

--- a/consult-mu.org
+++ b/consult-mu.org
@@ -282,6 +282,13 @@ This defines whether `consult-mu--reply-action' should reply to all or not."
                  (const :tag "Do not reply to all" nil)
                  (const :tag "Always reply to all" t)))
 
+(defcustom consult-mu-preview-function #'consult-mu--preview
+"The function that is used when previewing a message.
+By default it is bound to `consult-mu--preview'."
+  :group 'consult-mu
+  :type '(choice (function :tag "(Default) View Message a the preview buffer" consult-mu--preview)
+                 (function :tag "Custom Function")))
+
 (defcustom consult-mu-action #'consult-mu--view-action
   "The function that is used when selecting a message.
 By default it is bound to `consult-mu--view-action'."
@@ -1215,6 +1222,7 @@ When TRANSFORM is non-nil, the name of CAND is used for group."
 
 ***** actions
 In this section we define action functions that can be run on a candidate for example view, reply, forward, etc.
+
 ****** view messages
 #+begin_src emacs-lisp
 (defun consult-mu--view (msg noselect mark-as-read match-str)
@@ -1270,6 +1278,29 @@ To use this as the default action for `consult-mu', set
          (match-str (car (consult--command-split query))))
     (consult-mu--view msg nil consult-mu-mark-viewed-as-read match-str)
     (consult-mu-overlays-toggle consult-mu-view-buffer-name)))
+
+#+end_src
+
+****** preview message
+#+begin_src emacs-lisp
+(defun consult-mu--preview (cand)
+  "Preview the candidate, CAND.
+
+This is used to create a preview of message in
+`consult-mu-view-buffer-name' when `consult-mu-preview-key' is pressed
+in the minibuffer."
+      (when-let* ((info (cdr cand))
+                  (msg (plist-get info :msg))
+                  (msgid (substring-no-properties (plist-get msg :message-id)))
+                  (query (plist-get info :query))
+                  (match-str (car (consult--command-split query)))
+                  (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
+                  (buffer consult-mu-view-buffer-name))
+        (add-to-list 'consult-mu--view-buffers-list buffer)
+        (funcall (consult--buffer-preview) 'preview
+                 (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
+        (with-current-buffer consult-mu-view-buffer-name
+          (unless (one-window-p) (delete-other-windows)))))
 
 #+end_src
 
@@ -1419,29 +1450,15 @@ messages."
 This is passed as STATE to `consult--read' and is used to preview or do
 other actions on the candidate."
   (lambda (action cand)
-    (let ((preview (consult--buffer-preview)))
-      (pcase action
-        ('preview
-         (if cand
-             (when-let* ((info (cdr cand))
-                         (msg (plist-get info :msg))
-                         (query (plist-get info :query))
-                         (msgid (substring-no-properties (plist-get msg :message-id)))
-                         (match-str (car (consult--command-split query)))
-                         (match-str (car (consult--command-split query)))
-                         (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
-                         (buffer consult-mu-view-buffer-name))
-               ;;(get-buffer-create consult-mu-view-buffer-name)
-               (add-to-list 'consult-mu--view-buffers-list buffer)
-               (funcall preview action
-                        (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
-               (with-current-buffer consult-mu-view-buffer-name
-                 (unless (one-window-p) (delete-other-windows))))))
-        ('return
-         (save-mark-and-excursion
-           (consult-mu--execute-all-marks))
-         (setq consult-mu--override-group nil)
-         cand)))))
+    (pcase action
+      ('preview
+       (if cand
+           (funcall consult-mu-preview-function cand)))
+      ('return
+       (save-mark-and-excursion
+         (consult-mu--execute-all-marks))
+       (setq consult-mu--override-group nil)
+         cand))))
 
 #+end_src
 
@@ -1633,26 +1650,14 @@ If HIGHLIGHT is t, input is highlighted with
 This is passed as STATE to `consult--read' and is used to preview or do
 other actions on the candidate."
   (lambda (action cand)
-    (let ((preview (consult--buffer-preview)))
       (pcase action
         ('preview
          (if cand
-             (when-let* ((info (cdr cand))
-                         (msg (plist-get info :msg))
-                         (msgid (substring-no-properties (plist-get msg :message-id)))
-                         (query (plist-get info :query))
-                         (match-str (car (consult--command-split query)))
-                         (mu4e-headers-buffer-name consult-mu-headers-buffer-name)
-                         (buffer consult-mu-view-buffer-name))
-               (add-to-list 'consult-mu--view-buffers-list buffer)
-               (funcall preview action
-                        (consult-mu--view msg t consult-mu-mark-previewed-as-read match-str))
-               (with-current-buffer consult-mu-view-buffer-name
-                 (unless (one-window-p) (delete-other-windows))))))
+             (funcall consult-mu-preview-function cand)))
         ('return
          (save-mark-and-excursion
            (consult-mu--execute-all-marks))
-         cand)))))
+         cand))))
 
 #+end_src
 


### PR DESCRIPTION
This pull request introduces two significant enhancements to the consult-mu package:  

1.  Maildir Support:
2.  Added a new field `%m` to display maildir information in message headers
3.  Introduced a new face `consult-mu-maildir-face` for styling maildir annotations
4.  Allows users to include maildir path in header formatting, e.g., "%m20" will display 20 characters of the maildir path

Example header format:  

```elisp
(setq consult-mu-header-format "%d15%s50%m20")
```

1.  Customizable Preview Function:
2.  Created a new customization option `consult-mu-preview-function`
3.  Default preview function remains `consult-mu--preview`
4.  Allows users to define custom preview behaviors
5.  Refactored preview logic in multiple functions to use the new customizable function

Configuration example:  

```elisp
(setq consult-mu-preview-function #'my-custom-preview-function)
```

These changes provide more flexibility in displaying email metadata and customizing message preview behavior, enhancing the overall user experience of consult-mu.  


# Commit Messages


## (fb03e57)  Add support for maildir in header template

This commit introduces a new formatting option %m for displaying the maildir  
path in consult-mu header annotations. The feature allows users to include  
the maildir (email folder) path in their header format strings.  

Key changes:  

-   Added %m format specifier to parse and display maildir information
-   Created a new face 'consult-mu-maildir-face' for maildir annotations
-   Updated documentation in consult-mu.el and consult-mu.org

Example usage:  

-   Format string "%m20" will display the maildir path, truncated to 20 chars
-   Defaults to using font-lock-function-name-face for maildir display
-   Consistent with existing formatting options like %d (date) and %s (subject)

The implementation follows the existing pattern of formatting and propertizing  
header elements, ensuring seamless integration with the current consult-mu  
header annotation system.  

Fixes #55  


## (2a7891c)  Add customizable preview function for consult-mu

This commit introduces a new customization option \`consult-mu-preview-function\`  
that allows users to define their own preview behavior when browsing messages  
in consult-mu. The default preview function remains \`consult-mu&ndash;preview\`,  
which displays the message in the preview buffer and ensures a single-window  
view.  

Key changes:  

-   Added a new defcustom \`consult-mu-preview-function\`
-   Created a default preview function \`consult-mu&ndash;preview\`
-   Updated state functions to use the configurable preview function

Benefits:  

-   Increased flexibility for users who want custom preview behavior
-   Allows easy extension of preview functionality
-   Maintains existing default preview behavior

Example configuration:  
\`\`\`elisp  
(setq consult-mu-preview-function #'my-custom-preview-function)  
\`\`\`  

This change enables users to define their own preview logic while keeping the  
default implementation simple and functional.  

Fixes #54